### PR TITLE
feat: modernize icon button system with new variants

### DIFF
--- a/cupertino-adaptive/src/commonMain/kotlin/io/github/robinpcrd/cupertino/adaptive/AdaptiveIconButton.kt
+++ b/cupertino-adaptive/src/commonMain/kotlin/io/github/robinpcrd/cupertino/adaptive/AdaptiveIconButton.kt
@@ -20,9 +20,11 @@ package io.github.robinpcrd.cupertino.adaptive
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -48,7 +50,7 @@ fun AdaptiveIconButton(
 ) {
     AdaptiveWidget(
         adaptation = remember {
-            IconButtonAdaptation(isFilled = false)
+            IconButtonAdaptation(type = IconButtonType.Borderless)
         },
         adaptationScope = adaptation,
         material = {
@@ -87,11 +89,89 @@ fun AdaptiveFilledIconButton(
 ) {
     AdaptiveWidget(
         adaptation = remember {
-            IconButtonAdaptation(isFilled = true)
+            IconButtonAdaptation(type = IconButtonType.BezeledFilled)
         },
         adaptationScope = adaptation,
         material = {
             FilledIconButton(
+                onClick = onClick,
+                modifier = modifier,
+                enabled = enabled,
+                interactionSource = interactionSource,
+                content = content,
+                colors = it.colors,
+            )
+        },
+        cupertino = {
+            CupertinoIconButton(
+                onClick = onClick,
+                modifier = modifier,
+                enabled = enabled,
+                interactionSource = interactionSource,
+                content = content,
+                colors = it.colors
+            )
+        }
+    )
+}
+
+@ExperimentalAdaptiveApi
+@ExperimentalCupertinoApi
+@Composable
+fun AdaptiveOutlinedIconButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    adaptation: AdaptationScope<CupertinoIconButtonAdaptation, MaterialIconButtonAdaptation>.() -> Unit = {},
+    content: @Composable (() -> Unit)
+) {
+    AdaptiveWidget(
+        adaptation = remember {
+            IconButtonAdaptation(type = IconButtonType.BezeledGray)
+        },
+        adaptationScope = adaptation,
+        material = {
+            OutlinedIconButton(
+                onClick = onClick,
+                modifier = modifier,
+                enabled = enabled,
+                interactionSource = interactionSource,
+                content = content,
+                colors = it.colors,
+            )
+        },
+        cupertino = {
+            CupertinoIconButton(
+                onClick = onClick,
+                modifier = modifier,
+                enabled = enabled,
+                interactionSource = interactionSource,
+                content = content,
+                colors = it.colors
+            )
+        }
+    )
+}
+
+@ExperimentalAdaptiveApi
+@ExperimentalCupertinoApi
+@Composable
+fun AdaptiveTonalIconButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    adaptation: AdaptationScope<CupertinoIconButtonAdaptation, MaterialIconButtonAdaptation>.() -> Unit = {},
+    content: @Composable (() -> Unit)
+) {
+    AdaptiveWidget(
+        adaptation = remember {
+            IconButtonAdaptation(type = IconButtonType.Bezeled)
+        },
+        adaptationScope = adaptation,
+        material = {
+            FilledTonalIconButton(
                 onClick = onClick,
                 modifier = modifier,
                 enabled = enabled,
@@ -128,17 +208,23 @@ class MaterialIconButtonAdaptation internal constructor(
 
 }
 
+private enum class IconButtonType {
+    Bezeled, BezeledGray, BezeledFilled, Borderless;
+}
+
 @OptIn(ExperimentalAdaptiveApi::class)
 private class IconButtonAdaptation(
-    private val isFilled: Boolean
+    private val type: IconButtonType,
 ) : Adaptation<CupertinoIconButtonAdaptation, MaterialIconButtonAdaptation>() {
 
     @Composable
     override fun rememberCupertinoAdaptation(): CupertinoIconButtonAdaptation {
-        val colors = if (isFilled)
-            CupertinoIconButtonDefaults.filledButtonColors()
-        else
-            CupertinoIconButtonDefaults.plainButtonColors()
+        val colors = when (type) {
+            IconButtonType.Bezeled -> CupertinoIconButtonDefaults.bezeledButtonColors()
+            IconButtonType.BezeledGray -> CupertinoIconButtonDefaults.bezeledGrayButtonColors()
+            IconButtonType.BezeledFilled -> CupertinoIconButtonDefaults.bezeledFilledButtonColors()
+            IconButtonType.Borderless -> CupertinoIconButtonDefaults.borderlessButtonColors()
+        }
 
         return remember(colors) {
             CupertinoIconButtonAdaptation(
@@ -149,9 +235,12 @@ private class IconButtonAdaptation(
 
     @Composable
     override fun rememberMaterialAdaptation(): MaterialIconButtonAdaptation {
-        val colors = if (isFilled) {
-            IconButtonDefaults.filledIconButtonColors()
-        } else IconButtonDefaults.iconButtonColors()
+        val colors = when (type) {
+            IconButtonType.Bezeled -> IconButtonDefaults.filledTonalIconButtonColors()
+            IconButtonType.BezeledGray -> IconButtonDefaults.outlinedIconButtonColors()
+            IconButtonType.BezeledFilled -> IconButtonDefaults.filledIconButtonColors()
+            IconButtonType.Borderless -> IconButtonDefaults.iconButtonColors()
+        }
 
         return remember(colors) {
             MaterialIconButtonAdaptation(

--- a/cupertino-adaptive/src/commonMain/kotlin/io/github/robinpcrd/cupertino/adaptive/AdaptiveIconToggleButton.kt
+++ b/cupertino-adaptive/src/commonMain/kotlin/io/github/robinpcrd/cupertino/adaptive/AdaptiveIconToggleButton.kt
@@ -18,11 +18,13 @@ package io.github.robinpcrd.cupertino.adaptive
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.FilledIconToggleButton
+import androidx.compose.material3.FilledTonalIconToggleButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.IconToggleButtonColors
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.OutlinedIconToggleButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -53,7 +55,7 @@ fun AdaptiveIconToggleButton(
 ) {
     AdaptiveWidget(
         adaptation = remember {
-            IconToggleButtonAdaptation(isFilled = false)
+            IconToggleButtonAdaptation(type = IconToggleButtonType.Borderless)
         },
         adaptationScope = adaptation,
         material = {
@@ -95,48 +97,15 @@ fun AdaptiveIconToggleButton(
     adaptation: AdaptationScope<CupertinoIconToggleButtonAdaptation, MaterialIconToggleButtonAdaptation>.() -> Unit = {},
     icon: IconSource,
 ) {
-    val painter = icon.rememberPainter()
-
-    AdaptiveWidget(
-        adaptation = remember {
-            IconToggleButtonAdaptation(isFilled = false)
-        },
-        adaptationScope = adaptation,
-        material = {
-            IconToggleButton(
-                checked = checked,
-                onCheckedChange = onCheckedChange,
-                modifier = modifier,
-                enabled = enabled,
-                interactionSource = interactionSource,
-                content = {
-                    Icon(
-                        painter = painter,
-                        contentDescription = icon.contentDescription,
-                        tint = icon.tint.takeOrElse { LocalContentColor.current },
-                    )
-                },
-                colors = it.colors,
-            )
-        },
-        cupertino = {
-            CupertinoIconToggleButton(
-                checked = checked,
-                onCheckedChange = onCheckedChange,
-                modifier = modifier,
-                enabled = enabled,
-                interactionSource = interactionSource,
-                colors = it.colors,
-                shape = it.shape,
-                size = it.size,
-                content = {
-                    CupertinoIcon(
-                        painter = painter,
-                        contentDescription = icon.contentDescription,
-                        tint = icon.tint.takeOrElse { LocalContentColor.current },
-                    )
-                },
-            )
+    AdaptiveIconToggleButton(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        adaptation = adaptation,
+        content = {
+            IconContent(icon)
         }
     )
 }
@@ -155,7 +124,7 @@ fun AdaptiveFilledIconToggleButton(
 ) {
     AdaptiveWidget(
         adaptation = remember {
-            IconToggleButtonAdaptation(isFilled = true)
+            IconToggleButtonAdaptation(type = IconToggleButtonType.BezeledFilled)
         },
         adaptationScope = adaptation,
         material = {
@@ -198,29 +167,46 @@ fun AdaptiveFilledIconToggleButton(
     adaptation: AdaptationScope<CupertinoIconToggleButtonAdaptation, MaterialIconToggleButtonAdaptation>.() -> Unit = {},
     icon: IconSource,
 ) {
-    val painter = icon.rememberPainter()
+    AdaptiveFilledIconToggleButton(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        adaptation = adaptation,
+        content = {
+            IconContent(icon)
+        }
+    )
+}
 
+@ExperimentalAdaptiveApi
+@ExperimentalCupertinoApi
+@Composable
+fun AdaptiveTonalIconToggleButton(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    adaptation: AdaptationScope<CupertinoIconToggleButtonAdaptation, MaterialIconToggleButtonAdaptation>.() -> Unit = {},
+    content: @Composable (() -> Unit),
+) {
     AdaptiveWidget(
         adaptation = remember {
-            IconToggleButtonAdaptation(isFilled = true)
+            IconToggleButtonAdaptation(type = IconToggleButtonType.Bezeled)
         },
         adaptationScope = adaptation,
         material = {
-            FilledIconToggleButton(
+            FilledTonalIconToggleButton(
                 checked = checked,
                 onCheckedChange = onCheckedChange,
                 modifier = modifier,
                 enabled = enabled,
                 interactionSource = interactionSource,
+                content = content,
                 colors = it.colors,
                 shape = it.shape,
-                content = {
-                    Icon(
-                        painter = painter,
-                        contentDescription = icon.contentDescription,
-                        tint = icon.tint.takeOrElse { LocalContentColor.current },
-                    )
-                },
             )
         },
         cupertino = {
@@ -233,16 +219,123 @@ fun AdaptiveFilledIconToggleButton(
                 colors = it.colors,
                 shape = it.shape,
                 size = it.size,
-                content = {
-                    CupertinoIcon(
-                        painter = painter,
-                        contentDescription = icon.contentDescription,
-                        tint = icon.tint.takeOrElse { LocalContentColor.current },
-                    )
-                },
+                content = content,
             )
         }
     )
+}
+
+@ExperimentalAdaptiveApi
+@ExperimentalCupertinoApi
+@Composable
+fun AdaptiveTonalIconToggleButton(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    adaptation: AdaptationScope<CupertinoIconToggleButtonAdaptation, MaterialIconToggleButtonAdaptation>.() -> Unit = {},
+    icon: IconSource,
+) {
+    AdaptiveTonalIconToggleButton(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        adaptation = adaptation,
+        content = {
+            IconContent(icon)
+        }
+    )
+}
+
+@ExperimentalAdaptiveApi
+@ExperimentalCupertinoApi
+@Composable
+fun AdaptiveOutlinedIconToggleButton(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    adaptation: AdaptationScope<CupertinoIconToggleButtonAdaptation, MaterialIconToggleButtonAdaptation>.() -> Unit = {},
+    content: @Composable (() -> Unit),
+) {
+    AdaptiveWidget(
+        adaptation = remember {
+            IconToggleButtonAdaptation(type = IconToggleButtonType.BezeledGray)
+        },
+        adaptationScope = adaptation,
+        material = {
+            OutlinedIconToggleButton(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                modifier = modifier,
+                enabled = enabled,
+                interactionSource = interactionSource,
+                content = content,
+                colors = it.colors,
+                shape = it.shape,
+            )
+        },
+        cupertino = {
+            CupertinoIconToggleButton(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                modifier = modifier,
+                enabled = enabled,
+                interactionSource = interactionSource,
+                colors = it.colors,
+                shape = it.shape,
+                size = it.size,
+                content = content,
+            )
+        }
+    )
+}
+
+@ExperimentalAdaptiveApi
+@ExperimentalCupertinoApi
+@Composable
+fun AdaptiveOutlinedIconToggleButton(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    adaptation: AdaptationScope<CupertinoIconToggleButtonAdaptation, MaterialIconToggleButtonAdaptation>.() -> Unit = {},
+    icon: IconSource,
+) {
+    AdaptiveOutlinedIconToggleButton(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        adaptation = adaptation,
+        content = {
+            IconContent(icon)
+        }
+    )
+}
+
+@Composable
+private fun IconContent(icon: IconSource) {
+    val painter = icon.rememberPainter()
+    when (LocalTheme.current) {
+        Theme.Cupertino -> CupertinoIcon(
+            painter = painter,
+            contentDescription = icon.contentDescription,
+            tint = icon.tint.takeOrElse { LocalContentColor.current },
+        )
+
+        Theme.Material3 -> Icon(
+            painter = painter,
+            contentDescription = icon.contentDescription,
+            tint = icon.tint.takeOrElse { LocalContentColor.current },
+        )
+    }
 }
 
 @Stable
@@ -265,22 +358,30 @@ class MaterialIconToggleButtonAdaptation internal constructor(
     var shape: Shape by mutableStateOf(shape)
 }
 
+private enum class IconToggleButtonType {
+    Bezeled, BezeledGray, BezeledFilled, Borderless;
+}
+
 @ExperimentalAdaptiveApi
 private class IconToggleButtonAdaptation(
-    private val isFilled: Boolean
+    private val type: IconToggleButtonType,
 ) : Adaptation<CupertinoIconToggleButtonAdaptation, MaterialIconToggleButtonAdaptation>() {
 
     @Composable
     override fun rememberCupertinoAdaptation(): CupertinoIconToggleButtonAdaptation {
-        val colors = if (isFilled)
-            CupertinoIconToggleButtonDefaults.filledButtonColors()
-        else
-            CupertinoIconToggleButtonDefaults.plainButtonColors()
+        val colors = when (type) {
+            IconToggleButtonType.Bezeled -> CupertinoIconToggleButtonDefaults.bezeledButtonColors()
+            IconToggleButtonType.BezeledGray -> CupertinoIconToggleButtonDefaults.bezeledGrayButtonColors()
+            IconToggleButtonType.BezeledFilled -> CupertinoIconToggleButtonDefaults.bezeledFilledButtonColors()
+            IconToggleButtonType.Borderless -> CupertinoIconToggleButtonDefaults.borderlessButtonColors()
+        }
 
-        val shape = if (isFilled)
-            IconButtonDefaults.filledShape
-        else
-            IconButtonDefaults.outlinedShape
+        val shape = when (type) {
+            IconToggleButtonType.Bezeled -> IconButtonDefaults.filledShape
+            IconToggleButtonType.BezeledGray -> IconButtonDefaults.outlinedShape
+            IconToggleButtonType.BezeledFilled -> IconButtonDefaults.filledShape
+            IconToggleButtonType.Borderless -> IconButtonDefaults.outlinedShape
+        }
 
         return remember(colors) {
             CupertinoIconToggleButtonAdaptation(
@@ -292,15 +393,19 @@ private class IconToggleButtonAdaptation(
 
     @Composable
     override fun rememberMaterialAdaptation(): MaterialIconToggleButtonAdaptation {
-        val colors = if (isFilled)
-            IconButtonDefaults.filledIconToggleButtonColors()
-        else
-            IconButtonDefaults.iconToggleButtonColors()
+        val colors = when (type) {
+            IconToggleButtonType.Bezeled -> IconButtonDefaults.filledTonalIconToggleButtonColors()
+            IconToggleButtonType.BezeledGray -> IconButtonDefaults.outlinedIconToggleButtonColors()
+            IconToggleButtonType.BezeledFilled -> IconButtonDefaults.filledIconToggleButtonColors()
+            IconToggleButtonType.Borderless -> IconButtonDefaults.iconToggleButtonColors()
+        }
 
-        val shape = if (isFilled)
-            IconButtonDefaults.filledShape
-        else
-            IconButtonDefaults.outlinedShape
+        val shape = when (type) {
+            IconToggleButtonType.Bezeled -> IconButtonDefaults.filledShape
+            IconToggleButtonType.BezeledGray -> IconButtonDefaults.outlinedShape
+            IconToggleButtonType.BezeledFilled -> IconButtonDefaults.filledShape
+            IconToggleButtonType.Borderless -> IconButtonDefaults.outlinedShape
+        }
 
         return remember(colors, shape) {
             MaterialIconToggleButtonAdaptation(

--- a/cupertino/src/commonMain/kotlin/io/github/robinpcrd/cupertino/CupertinoButton.kt
+++ b/cupertino/src/commonMain/kotlin/io/github/robinpcrd/cupertino/CupertinoButton.kt
@@ -247,116 +247,12 @@ object CupertinoButtonDefaults {
         disabledContentColor = disabledContentColor,
         indicationColor = indicationColor,
     )
-
-    /**
-     * Filled button with .borderedProminent SwiftUI style
-     * */
-    @Composable
-    @ReadOnlyComposable
-    @Deprecated(
-        "Use filledButtonColors instead",
-        replaceWith = ReplaceWith(
-            "filledButtonColors(contentColor,containerColor,disabledContentColor,disabledContainerColor,indicationColor)",
-            "io.github.robinpcrd.cupertino.filledButtonColors"
-        )
-    )
-    fun borderedProminentButtonColors(
-        contentColor: Color = Color.White,
-        containerColor: Color = CupertinoTheme.colorScheme.accent,
-        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
-        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
-        indicationColor: Color = contentColor.copy(alpha = .2f)
-    ): CupertinoButtonColors = filledButtonColors(
-        containerColor = containerColor,
-        contentColor = contentColor,
-        disabledContainerColor = disabledContainerColor,
-        disabledContentColor = disabledContentColor,
-        indicationColor = indicationColor
-    )
-
-    /**
-     * Tinted button with .bordered SwiftUI style and [contentColor] tint
-     * */
-    @Deprecated(
-        "Use tintedButtonColors instead",
-        replaceWith = ReplaceWith(
-            "tintedButtonColors(contentColor,containerColor,disabledContentColor,disabledContainerColor,indicationColor)",
-            "io.github.robinpcrd.cupertino.tintedButtonColors"
-        )
-    )
-    @Composable
-    @ReadOnlyComposable
-    fun borderedButtonColors(
-        contentColor: Color = CupertinoTheme.colorScheme.accent,
-        containerColor: Color = contentColor.copy(alpha = CupertinoButtonTokens.BorderedButtonAlpha),
-        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
-        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
-        indicationColor: Color = contentColor.copy(alpha = .15f)
-    ): CupertinoButtonColors = tintedButtonColors(
-        containerColor = containerColor,
-        contentColor = contentColor,
-        disabledContainerColor = disabledContainerColor,
-        disabledContentColor = disabledContentColor,
-        indicationColor = indicationColor,
-    )
-
-    /**
-     * SwiftUI .borderless button
-     * */
-    @Deprecated(
-        "Use plainButtonColors instead",
-        replaceWith = ReplaceWith(
-            "plainButtonColors(contentColor,containerColor,disabledContentColor,disabledContainerColor,indicationColor)",
-            "io.github.robinpcrd.cupertino.plainButtonColors"
-        )
-    )
-    @Composable
-    @ReadOnlyComposable
-    fun borderlessButtonColors(
-        contentColor: Color = CupertinoTheme.colorScheme.accent,
-        containerColor: Color = Color.Transparent,
-        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
-        disabledContainerColor: Color = Color.Transparent,
-        indicationColor: Color = Color.Transparent
-    ): CupertinoButtonColors = plainButtonColors(
-        contentColor = contentColor,
-        containerColor = containerColor,
-        disabledContainerColor = disabledContainerColor,
-        disabledContentColor = disabledContentColor,
-        indicationColor = indicationColor
-    )
-
-    /**
-     * Tinted button with .bordered SwiftUI with default tint
-     * */
-    @Deprecated(
-        "Use grayButtonColors instead",
-        replaceWith = ReplaceWith(
-            "grayButtonColors(contentColor,containerColor,disabledContentColor,disabledContainerColor,indicationColor)",
-            "io.github.robinpcrd.cupertino.grayButtonColors"
-        )
-    )
-    @Composable
-    @ReadOnlyComposable
-    fun borderedGrayButtonColors(
-        contentColor: Color = CupertinoTheme.colorScheme.accent,
-        containerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
-        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
-        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
-        indicationColor: Color = CupertinoColors.DefaultAlpha
-    ): CupertinoButtonColors = grayButtonColors(
-        containerColor = containerColor,
-        contentColor = contentColor,
-        disabledContainerColor = disabledContainerColor,
-        disabledContentColor = disabledContentColor,
-        indicationColor = indicationColor,
-    )
 }
 
 internal object CupertinoButtonTokens {
     const val PressedPlainButonAlpha = .33f
     val IconButtonSize = 44.dp
-    const val BorderedButtonAlpha = .2f
+    const val BorderedButtonAlpha = .15f
 }
 
 internal val ZeroPadding = PaddingValues(0.dp)

--- a/cupertino/src/commonMain/kotlin/io/github/robinpcrd/cupertino/CupertinoIconButton.kt
+++ b/cupertino/src/commonMain/kotlin/io/github/robinpcrd/cupertino/CupertinoIconButton.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -81,7 +82,7 @@ fun CupertinoIconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier.Companion,
     enabled: Boolean = true,
-    colors: CupertinoIconButtonColors = CupertinoIconButtonDefaults.plainButtonColors(),
+    colors: CupertinoIconButtonColors = CupertinoIconButtonDefaults.borderlessButtonColors(),
     border: BorderStroke? = null,
     size: CupertinoIconButtonSize = CupertinoIconButtonSize.Unspecified,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -126,7 +127,7 @@ fun CupertinoIconToggleButton(
     modifier: Modifier = Modifier.Companion,
     enabled: Boolean = true,
     shape: Shape = IconButtonDefaults.filledShape,
-    colors: CupertinoIconToggleButtonColors = CupertinoIconToggleButtonDefaults.plainButtonColors(),
+    colors: CupertinoIconToggleButtonColors = CupertinoIconToggleButtonDefaults.borderlessButtonColors(),
     size: CupertinoIconButtonSize = CupertinoIconButtonSize.Unspecified,
     interactionSource: MutableInteractionSource? = null,
     content: @Composable () -> Unit
@@ -317,6 +318,11 @@ class CupertinoIconToggleButtonColors(
 
 object CupertinoIconButtonDefaults {
 
+    @Deprecated(
+        message = "Use borderlessButtonColors instead",
+        replaceWith = ReplaceWith("borderlessButtonColors(containerColor, contentColor, disabledContainerColor, disabledContentColor)"),
+        level = DeprecationLevel.ERROR,
+    )
     @Composable
     @ReadOnlyComposable
     fun filledButtonColors(
@@ -331,6 +337,11 @@ object CupertinoIconButtonDefaults {
         disabledContentColor = disabledContentColor,
     )
 
+    @Deprecated(
+        message = "Use borderlessButtonColors instead",
+        replaceWith = ReplaceWith("borderlessButtonColors(containerColor, contentColor, disabledContainerColor, disabledContentColor)"),
+        level = DeprecationLevel.ERROR,
+    )
     @Composable
     @ReadOnlyComposable
     fun plainButtonColors(
@@ -344,10 +355,70 @@ object CupertinoIconButtonDefaults {
         disabledContainerColor = disabledContainerColor,
         disabledContentColor = disabledContentColor,
     )
+
+    @Composable
+    @ReadOnlyComposable
+    fun borderlessButtonColors(
+        containerColor: Color = Color.Transparent,
+        contentColor: Color = CupertinoTheme.colorScheme.accent,
+        disabledContainerColor: Color = Color.Transparent,
+        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
+    ): CupertinoIconButtonColors = CupertinoIconButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+    )
+
+    @Composable
+    @ReadOnlyComposable
+    fun bezeledButtonColors(
+        contentColor: Color = CupertinoTheme.colorScheme.accent,
+        containerColor: Color = contentColor.copy(alpha = CupertinoButtonTokens.BorderedButtonAlpha),
+        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
+        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
+    ): CupertinoIconButtonColors = CupertinoIconButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+    )
+
+    @Composable
+    @ReadOnlyComposable
+    fun bezeledGrayButtonColors(
+        containerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
+        contentColor: Color = CupertinoTheme.colorScheme.accent,
+        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
+        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
+    ): CupertinoIconButtonColors = CupertinoIconButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor
+    )
+
+    @Composable
+    @ReadOnlyComposable
+    fun bezeledFilledButtonColors(
+        containerColor: Color = CupertinoTheme.colorScheme.accent,
+        contentColor: Color = Color.White,
+        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
+        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
+    ): CupertinoIconButtonColors = CupertinoIconButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor
+    )
 }
 
 object CupertinoIconToggleButtonDefaults {
-
+    @Deprecated(
+        message = "Use bezeledFilledButtonColors instead",
+        replaceWith = ReplaceWith("bezeledFilledButtonColors(containerColor, contentColor, disabledContainerColor, disabledContentColor, checkedContainerColor, checkedContentColor)"),
+        level = DeprecationLevel.ERROR,
+    )
     @Composable
     @ReadOnlyComposable
     fun filledButtonColors(
@@ -356,7 +427,30 @@ object CupertinoIconToggleButtonDefaults {
         disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
         disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
         checkedContainerColor: Color = CupertinoTheme.colorScheme.accent,
-        checkedContentColor: Color = Color.Companion.White,
+        checkedContentColor: Color = Color.White,
+    ): CupertinoIconToggleButtonColors = CupertinoIconToggleButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+        checkedContainerColor = checkedContainerColor,
+        checkedContentColor = checkedContentColor,
+    )
+
+    @Deprecated(
+        message = "Use borderlessButtonColors instead",
+        replaceWith = ReplaceWith("borderlessButtonColors(containerColor, contentColor, disabledContainerColor, disabledContentColor, checkedContainerColor, checkedContentColor)"),
+        level = DeprecationLevel.ERROR,
+    )
+    @Composable
+    @ReadOnlyComposable
+    fun plainButtonColors(
+        containerColor: Color = Color.Transparent,
+        contentColor: Color = CupertinoTheme.colorScheme.accent,
+        disabledContainerColor: Color = Color.Transparent,
+        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
+        checkedContainerColor: Color = Color.Transparent,
+        checkedContentColor: Color = CupertinoTheme.colorScheme.accent,
     ): CupertinoIconToggleButtonColors = CupertinoIconToggleButtonColors(
         containerColor = containerColor,
         contentColor = contentColor,
@@ -368,12 +462,12 @@ object CupertinoIconToggleButtonDefaults {
 
     @Composable
     @ReadOnlyComposable
-    fun plainButtonColors(
-        containerColor: Color = Color.Companion.Transparent,
+    fun borderlessButtonColors(
+        containerColor: Color = Color.Transparent,
         contentColor: Color = LocalContentColor.current,
-        disabledContainerColor: Color = Color.Companion.Transparent,
+        disabledContainerColor: Color = Color.Transparent,
         disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
-        checkedContainerColor: Color = Color.Companion.Transparent,
+        checkedContainerColor: Color = Color.Transparent,
         checkedContentColor: Color = CupertinoTheme.colorScheme.accent,
     ): CupertinoIconToggleButtonColors = CupertinoIconToggleButtonColors(
         containerColor = containerColor,
@@ -381,6 +475,64 @@ object CupertinoIconToggleButtonDefaults {
         disabledContainerColor = disabledContainerColor,
         disabledContentColor = disabledContentColor,
         checkedContainerColor = checkedContainerColor,
-        checkedContentColor = checkedContentColor
+        checkedContentColor = checkedContentColor,
+    )
+
+    @Composable
+    @ReadOnlyComposable
+    fun bezeledButtonColors(
+        containerColor: Color = CupertinoTheme.colorScheme.accent.copy(alpha = CupertinoButtonTokens.BorderedButtonAlpha),
+        contentColor: Color = LocalContentColor.current,
+        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
+        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
+        checkedContainerColor: Color = lerp(
+            CupertinoTheme.colorScheme.accent,
+            LocalContentColor.current,
+            0.2f
+        ),
+        checkedContentColor: Color = Color.White,
+    ): CupertinoIconToggleButtonColors = CupertinoIconToggleButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+        checkedContainerColor = checkedContainerColor,
+        checkedContentColor = checkedContentColor,
+    )
+
+    @Composable
+    @ReadOnlyComposable
+    fun bezeledGrayButtonColors(
+        containerColor: Color = CupertinoTheme.colorScheme.systemGroupedBackground,
+        contentColor: Color = LocalContentColor.current,
+        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
+        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
+        checkedContainerColor: Color = LocalContentColor.current,
+        checkedContentColor: Color = CupertinoTheme.colorScheme.systemGroupedBackground,
+    ): CupertinoIconToggleButtonColors = CupertinoIconToggleButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+        checkedContainerColor = checkedContainerColor,
+        checkedContentColor = checkedContentColor,
+    )
+
+    @Composable
+    @ReadOnlyComposable
+    fun bezeledFilledButtonColors(
+        containerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
+        contentColor: Color = LocalContentColor.current,
+        disabledContainerColor: Color = CupertinoTheme.colorScheme.quaternarySystemFill,
+        disabledContentColor: Color = CupertinoTheme.colorScheme.tertiaryLabel,
+        checkedContainerColor: Color = CupertinoTheme.colorScheme.accent,
+        checkedContentColor: Color = Color.White,
+    ): CupertinoIconToggleButtonColors = CupertinoIconToggleButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+        checkedContainerColor = checkedContainerColor,
+        checkedContentColor = checkedContentColor,
     )
 }

--- a/example/composeApp/build.gradle.kts
+++ b/example/composeApp/build.gradle.kts
@@ -112,6 +112,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)
             implementation(libs.maplibre.android.sdk)
+            implementation(compose.uiTooling)
         }
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)

--- a/example/composeApp/src/commonMain/kotlin/cupertino/CupertinoWidgetsScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/cupertino/CupertinoWidgetsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -128,6 +129,7 @@ import io.github.robinpcrd.cupertino.adaptive.icons.Add
 import io.github.robinpcrd.cupertino.adaptive.icons.Lock
 import io.github.robinpcrd.cupertino.adaptive.icons.Settings
 import io.github.robinpcrd.cupertino.adaptive.icons.Share
+import io.github.robinpcrd.cupertino.adaptive.icons.ThumbUp
 import io.github.robinpcrd.cupertino.cancel
 import io.github.robinpcrd.cupertino.default
 import io.github.robinpcrd.cupertino.destructive
@@ -138,6 +140,7 @@ import io.github.robinpcrd.cupertino.icons.filled.Banknote
 import io.github.robinpcrd.cupertino.icons.filled.Gearshape
 import io.github.robinpcrd.cupertino.icons.filled.Person
 import io.github.robinpcrd.cupertino.icons.filled.Pin
+import io.github.robinpcrd.cupertino.icons.filled.Play
 import io.github.robinpcrd.cupertino.icons.filled.Trash
 import io.github.robinpcrd.cupertino.icons.outlined.AppleLogo
 import io.github.robinpcrd.cupertino.icons.outlined.Bookmark
@@ -147,6 +150,7 @@ import io.github.robinpcrd.cupertino.icons.outlined.Iphone
 import io.github.robinpcrd.cupertino.icons.outlined.MoonStars
 import io.github.robinpcrd.cupertino.icons.outlined.Paintpalette
 import io.github.robinpcrd.cupertino.icons.outlined.Paperclip
+import io.github.robinpcrd.cupertino.icons.outlined.Play
 import io.github.robinpcrd.cupertino.icons.outlined.RectangleStack
 import io.github.robinpcrd.cupertino.icons.outlined.SquareAndArrowUp
 import io.github.robinpcrd.cupertino.icons.outlined.SquareSplit1x2
@@ -1106,7 +1110,7 @@ private fun ColorButtons(
                     CupertinoColors.systemBlue(true)
                 )
             },
-            colors = CupertinoIconButtonDefaults.plainButtonColors(
+            colors = CupertinoIconButtonDefaults.bezeledButtonColors(
                 contentColor = CupertinoColors.systemBlue,
             )
         ) {
@@ -1122,7 +1126,7 @@ private fun ColorButtons(
                     CupertinoColors.systemGreen(true)
                 )
             },
-            colors = CupertinoIconButtonDefaults.plainButtonColors(
+            colors = CupertinoIconButtonDefaults.bezeledButtonColors(
                 contentColor = CupertinoColors.systemGreen,
             )
         ) {
@@ -1138,7 +1142,7 @@ private fun ColorButtons(
                     CupertinoColors.systemPurple(true)
                 )
             },
-            colors = CupertinoIconButtonDefaults.plainButtonColors(
+            colors = CupertinoIconButtonDefaults.bezeledButtonColors(
                 contentColor = CupertinoColors.systemPurple,
             )
         ) {
@@ -1155,7 +1159,7 @@ private fun ColorButtons(
                     CupertinoColors.systemOrange(true)
                 )
             },
-            colors = CupertinoIconButtonDefaults.plainButtonColors(
+            colors = CupertinoIconButtonDefaults.bezeledButtonColors(
                 contentColor = CupertinoColors.systemOrange,
             )
         ) {
@@ -1171,7 +1175,7 @@ private fun ColorButtons(
                     CupertinoColors.systemRed(true)
                 )
             },
-            colors = CupertinoIconButtonDefaults.plainButtonColors(
+            colors = CupertinoIconButtonDefaults.bezeledButtonColors(
                 contentColor = CupertinoColors.systemRed,
             )
         ) {
@@ -1183,6 +1187,7 @@ private fun ColorButtons(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun SectionScope.ButtonsExample() {
     SectionItem {
@@ -1204,6 +1209,14 @@ private fun SectionScope.ButtonsExample() {
                     ToggleableState.Indeterminate -> ToggleableState.On
                 }
             })
+        }
+    }
+
+    SectionItem {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             CupertinoIconButton(
                 onClick = {},
             ) {
@@ -1214,7 +1227,7 @@ private fun SectionScope.ButtonsExample() {
             }
             CupertinoIconButton(
                 onClick = {},
-                colors = CupertinoIconButtonDefaults.filledButtonColors()
+                colors = CupertinoIconButtonDefaults.bezeledButtonColors()
             ) {
                 CupertinoIcon(
                     imageVector = AdaptiveIcons.Outlined.Add,
@@ -1223,15 +1236,19 @@ private fun SectionScope.ButtonsExample() {
             }
             CupertinoIconButton(
                 onClick = {},
-                colors = CupertinoIconButtonDefaults.filledButtonColors(
-                    contentColor = CupertinoTheme.colorScheme.accent,
-                    containerColor = CupertinoTheme.colorScheme.quaternarySystemFill,
-                    disabledContentColor = CupertinoTheme.colorScheme.tertiaryLabel,
-                    disabledContainerColor = CupertinoTheme.colorScheme.quaternarySystemFill,
-                )
+                colors = CupertinoIconButtonDefaults.bezeledGrayButtonColors()
             ) {
                 CupertinoIcon(
                     imageVector = AdaptiveIcons.Outlined.Settings,
+                    contentDescription = null,
+                )
+            }
+            CupertinoIconButton(
+                onClick = {},
+                colors = CupertinoIconButtonDefaults.bezeledFilledButtonColors()
+            ) {
+                CupertinoIcon(
+                    imageVector = AdaptiveIcons.Outlined.ThumbUp,
                     contentDescription = null,
                 )
             }
@@ -1371,15 +1388,15 @@ private fun SectionScope.ButtonsExample() {
                     CupertinoIconToggleButton(
                         checked = checked,
                         onCheckedChange = { checked = it },
-                        colors = CupertinoIconToggleButtonDefaults.filledButtonColors(),
+                        size = CupertinoIconButtonSize.Large,
                     ) {
                         CupertinoIcon(
-                            imageVector = AdaptiveIcons.Outlined.Add,
+                            imageVector = if (checked) CupertinoIcons.Filled.Play else CupertinoIcons.Outlined.Play,
                             contentDescription = null
                         )
                     }
                 },
-                description = "Filled"
+                description = "Borderless",
             )
             IconButtonExampleLayout(
                 button = {
@@ -1387,16 +1404,73 @@ private fun SectionScope.ButtonsExample() {
                     CupertinoIconToggleButton(
                         checked = checked,
                         onCheckedChange = { checked = it },
-                        colors = CupertinoIconToggleButtonDefaults.filledButtonColors(),
+                        size = CupertinoIconButtonSize.Large,
+                        colors = CupertinoIconToggleButtonDefaults.bezeledGrayButtonColors(),
+                    ) {
+                        CupertinoIcon(
+                            imageVector = if (checked) CupertinoIcons.Filled.Play else CupertinoIcons.Outlined.Play,
+                            contentDescription = null
+                        )
+                    }
+                },
+                description = "Bezeled\nGray",
+            )
+            IconButtonExampleLayout(
+                button = {
+                    var checked by remember { mutableStateOf(false) }
+                    CupertinoIconToggleButton(
+                        checked = checked,
+                        onCheckedChange = { checked = it },
+                        size = CupertinoIconButtonSize.Large,
+                        colors = CupertinoIconToggleButtonDefaults.bezeledButtonColors(),
+                    ) {
+                        CupertinoIcon(
+                            imageVector = if (checked) CupertinoIcons.Filled.Play else CupertinoIcons.Outlined.Play,
+                            contentDescription = null
+                        )
+                    }
+                },
+                description = "Bezeled",
+            )
+            IconButtonExampleLayout(
+                button = {
+                    var checked by remember { mutableStateOf(false) }
+                    CupertinoIconToggleButton(
+                        checked = checked,
+                        onCheckedChange = { checked = it },
+                        size = CupertinoIconButtonSize.Large,
+                        colors = CupertinoIconToggleButtonDefaults.bezeledFilledButtonColors(),
+                    ) {
+                        CupertinoIcon(
+                            imageVector = if (checked) CupertinoIcons.Filled.Play else CupertinoIcons.Outlined.Play,
+                            contentDescription = null
+                        )
+                    }
+                },
+                description = "Bezeled\nFilled",
+            )
+        }
+    }
+
+    SectionItem {
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            IconButtonExampleLayout(
+                button = {
+                    var checked by remember { mutableStateOf(false) }
+                    CupertinoIconToggleButton(
+                        checked = checked,
+                        onCheckedChange = { checked = it },
                         enabled = false,
                     ) {
                         CupertinoIcon(
-                            imageVector = AdaptiveIcons.Outlined.Add,
-                            contentDescription = null
+                            imageVector = if (checked) CupertinoIcons.Filled.Play else CupertinoIcons.Outlined.Play,
+                            contentDescription = null,
                         )
                     }
                 },
-                description = "Filled\nDisabled"
+                description = "Borderless\nDisabled"
             )
             IconButtonExampleLayout(
                 button = {
@@ -1404,30 +1478,16 @@ private fun SectionScope.ButtonsExample() {
                     CupertinoIconToggleButton(
                         checked = checked,
                         onCheckedChange = { checked = it },
-                    ) {
-                        CupertinoIcon(
-                            imageVector = AdaptiveIcons.Outlined.Add,
-                            contentDescription = null
-                        )
-                    }
-                },
-                description = "Plain",
-            )
-            IconButtonExampleLayout(
-                button = {
-                    var checked by remember { mutableStateOf(false) }
-                    CupertinoIconToggleButton(
-                        checked = checked,
-                        onCheckedChange = { checked = it },
+                        colors = CupertinoIconToggleButtonDefaults.bezeledButtonColors(),
                         enabled = false,
                     ) {
                         CupertinoIcon(
-                            imageVector = AdaptiveIcons.Outlined.Add,
+                            imageVector = if (checked) CupertinoIcons.Filled.Play else CupertinoIcons.Outlined.Play,
                             contentDescription = null
                         )
                     }
                 },
-                description = "Plain\nDisabled"
+                description = "Bezeled\nDisabled"
             )
         }
     }


### PR DESCRIPTION
- Add bezeled, bezeledGray, bezeledFilled, borderless color variants for CupertinoIconButton/ToggleButton
- Deprecate old naming (filledButtonColors -> bezeledFilledButtonColors, plainButtonColors -> borderlessButtonColors) 
- Refactor adaptive icon buttons to use type enum
- Add AdaptiveTonalIconButton and AdaptiveOutlinedIconButton variants
- Add AdaptiveTonalIconToggleButton and AdaptiveOutlinedIconToggleButton variants
- Update BorderedButtonAlpha from 0.2f to 0.15f to match iOS guidelines